### PR TITLE
un-capitalize 'w' in windows.h, winsock2.h.  This was a corner case that...

### DIFF
--- a/FireLog.cpp
+++ b/FireLog.cpp
@@ -5,8 +5,8 @@
 #include <errno.h>
 #include <time.h>
 #ifdef WIN32
-  #include <Winsock2.h>
-  #include <Windows.h>
+  #include <winsock2.h>
+  #include <windows.h>
 #else
   #define LOG_THREAD_ID
   #include <sys/time.h>


### PR DESCRIPTION
... caused mingw linux cross-compile build to fail because of case sensitivity, but wasn't an issue for building on windows or linux native.
